### PR TITLE
fix: Types on Translators

### DIFF
--- a/src/Translator.ts
+++ b/src/Translator.ts
@@ -1,4 +1,5 @@
-/*! Copyright (c) 2019, XAPPmedia */
+/*! Copyright (c) 2019, XAPP AI */
+
 /**
  * Translate one object to another.
  *
@@ -8,14 +9,14 @@
  * @template F from
  * @template T to
  */
-export abstract class Translator<F, T, P extends object = Record<string, unknown>> {
+export abstract class Translator<F, T, P = unknown> {
     /**
      * Translate from F to T.
      *
      * @abstract
      * @param {F} from
-     * @returns {T}
-     * @memberof Translator
+     * @param {P} props
+     * @returns {T} to 
      */
-    abstract translate(from: F, props?: P): T;
+    public abstract translate(from: F, props?: P): T;
 }

--- a/src/__test__/Translator.test.ts
+++ b/src/__test__/Translator.test.ts
@@ -1,0 +1,46 @@
+/*! Copyright (c) 2019, XAPP AI */
+import { expect } from "chai";
+import { Translator } from "../Translator";
+
+class TestTranslator extends Translator<string, number> {
+    public translate(from: string, props?: Record<string, unknown> | undefined): number {
+        console.log(props);
+        return Number(from);
+    }
+}
+
+class TestWithPropsTranslator extends Translator<number, string> {
+    public translate(from: number, props?: string): string {
+        if (props) {
+            return `${from} ${props}`;
+        }
+        return `${from}`
+    }
+}
+
+class TestWithFullGenericsTranslator extends Translator<boolean, string, string[]> {
+    public translate(from: boolean, props?: string[] | undefined): string {
+        if (props) {
+            return 'hasProps';
+        }
+
+        return `${from}`;
+    }
+}
+
+describe(`${Translator.name}`, () => {
+    describe("#constructor()", () => {
+        it("returns an instance of itself", () => {
+            expect(new TestTranslator()).to.be.instanceOf(TestTranslator);
+            expect(new TestWithPropsTranslator()).to.be.instanceOf(TestWithPropsTranslator);
+            expect(new TestWithFullGenericsTranslator()).to.be.instanceOf(TestWithFullGenericsTranslator);
+        });
+    });
+    describe(`#translate()`, () => {
+        it("accepts optional props", () => {
+            const t = new TestWithPropsTranslator();
+            expect(t.translate(1, "foo")).to.exist;
+            expect(t.translate(2)).to.exist;
+        });
+    });
+});


### PR DESCRIPTION
The existing `P` for optional props was too limiting.